### PR TITLE
Update README link to Rackspace IP/OSS Policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ From an IP (copyright) perspective, the agreement is dedicated to the public dom
 
 #### Employer
 
-* A [Model IP/OSS Policy](https://processmechanics.com/2015/07/23/a-model-ip-and-open-source-contribution-policy/), based on the employee IP agreement used by Rackspace
+* A [Model IP/OSS Policy](http://blog.rackspace.com/rackspaces-policy-on-contributing-to-open-source), based on the employee IP agreement used by Rackspace
 
 #### Employee
 


### PR DESCRIPTION
Suggest alternate link to processmechanics webpage that ostensibly contained Rackspace Model IP/OSS Policy. The new link is to Rackspace blogpost on the policy. Maybe not the best alternative, but one just the same.

@mlinksva I'm (still) new to PRs so forgive me if this is clunky or out of place. 

