### PR TITLE
blockquote statutes

### DIFF
--- a/Balanced_Employee_IP_Agreement.md
+++ b/Balanced_Employee_IP_Agreement.md
@@ -54,16 +54,16 @@ Date: ＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿
 
 <http://leginfo.legislature.ca.gov/faces/codes_displayText.xhtml?division=3.&chapter=2.&lawCode=LAB&article=3.5.>
 
-> 2870\.  (a) Any provision in an employment agreement which provides that an employee shall assign, or offer to assign, any of his or her rights in an invention to his or her employer shall not apply to an invention that the employee developed entirely on his or her own time without using the employer’s equipment, supplies, facilities, or trade secret information except for those inventions that either:
-> (1) Relate at the time of conception or reduction to practice of the invention to the employer’s business, or actual or demonstrably anticipated research or development of the employer; or
-> (2) Result from any work performed by the employee for the employer.
-> (b) To the extent a provision in an employment agreement purports to require an employee to assign an invention otherwise excluded from being required to be assigned under subdivision (a), the provision is against the public policy of this state and is unenforceable.
+> 2870\.  (a) Any provision in an employment agreement which provides that an employee shall assign, or offer to assign, any of his or her rights in an invention to his or her employer shall not apply to an invention that the employee developed entirely on his or her own time without using the employer’s equipment, supplies, facilities, or trade secret information except for those inventions that either:  
+> (1) Relate at the time of conception or reduction to practice of the invention to the employer’s business, or actual or demonstrably anticipated research or development of the employer; or  
+> (2) Result from any work performed by the employee for the employer.  
+> (b) To the extent a provision in an employment agreement purports to require an employee to assign an invention otherwise excluded from being required to be assigned under subdivision (a), the provision is against the public policy of this state and is unenforceable.  
 > (Amended by Stats. 1991, Ch. 647, Sec. 5.)
 >
-> 2871\.  No employer shall require a provision made void and unenforceable by Section 2870 as a condition of employment or continued employment. Nothing in this article shall be construed to forbid or restrict the right of an employer to provide in contracts of employment for disclosure, provided that any such disclosures be received in confidence, of all of the employee’s inventions made solely or jointly with others during the term of his or her employment, a review process by the employer to determine such issues as may arise, and for full title to certain patents and inventions to be in the United States, as required by contracts between the employer and the United States or any of its agencies.
+> 2871\.  No employer shall require a provision made void and unenforceable by Section 2870 as a condition of employment or continued employment. Nothing in this article shall be construed to forbid or restrict the right of an employer to provide in contracts of employment for disclosure, provided that any such disclosures be received in confidence, of all of the employee’s inventions made solely or jointly with others during the term of his or her employment, a review process by the employer to determine such issues as may arise, and for full title to certain patents and inventions to be in the United States, as required by contracts between the employer and the United States or any of its agencies.  
 > (Added by Stats. 1979, Ch. 1001.)
 >
-> 2872\.  If an employment agreement entered into after January 1, 1980, contains a provision requiring the employee to assign or offer to assign any of his or her rights in any invention to his or her employer, the employer must also, at the time the agreement is made, provide a written notification to the employee that the agreement does not apply to an invention which qualifies fully under the provisions of Section 2870. In any suit or action arising thereunder, the burden of proof shall be on the employee claiming the benefits of its provisions.
+> 2872\.  If an employment agreement entered into after January 1, 1980, contains a provision requiring the employee to assign or offer to assign any of his or her rights in any invention to his or her employer, the employer must also, at the time the agreement is made, provide a written notification to the employee that the agreement does not apply to an invention which qualifies fully under the provisions of Section 2870. In any suit or action arising thereunder, the burden of proof shall be on the employee claiming the benefits of its provisions.  
 > (Added by Stats. 1979, Ch. 1001.)
 
 #### Delaware
@@ -74,8 +74,7 @@ Date: ＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿
 >
 > Any provision in an employment agreement which provides that the employee shall assign or offer to assign any of the employee's rights in an invention to the employee's employer shall not apply to an invention that the employee developed entirely on the employee's own time without using the employer's equipment, supplies, facility or trade secret information, except for those inventions that:
 >
-> (1) Relate to the employer's business or actual or demonstrably anticipated research or development; or
->
+> (1) Relate to the employer's business or actual or demonstrably anticipated research or development; or  
 > (2) Result from any work performed by the employee for the employer.
 >
 > To the extent a provision in an employment agreement purports to apply to the type of invention described, it is against the public policy of this State and is unenforceable. An employer may not require a provision of an employment agreement made unenforceable under this section as a condition of employment or continued employment.
@@ -86,49 +85,49 @@ Date: ＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿
 
 <http://www.ilga.gov/legislation/ilcs/ilcs3.asp?ActID=2238>
 
-> (765 ILCS 1060/1) (from Ch. 140, par. 301)
-> Sec. 1. This Act shall be known and may be cited as the "Employee Patent Act".
+> (765 ILCS 1060/1) (from Ch. 140, par. 301)  
+> Sec. 1. This Act shall be known and may be cited as the "Employee Patent Act".  
 > (Source: P.A. 83-493.)
 >
-> (765 ILCS 1060/2) (from Ch. 140, par. 302)
-> Sec. 2. Employee rights to inventions - conditions). (1) A provision in an employment agreement which provides that an employee shall assign or offer to assign any of the employee's rights in an invention to the employer does not apply to an invention for which no equipment, supplies, facilities, or trade secret information of the employer was used and which was developed entirely on the employee's own time, unless (a) the invention relates (i) to the business of the employer, or (ii) to the employer's actual or demonstrably anticipated research or development, or (b) the invention results from any work performed by the employee for the employer. Any provision which purports to apply to such an invention is to that extent against the public policy of this State and is to that extent void and unenforceable. The employee shall bear the burden of proof in establishing that his invention qualifies under this subsection.
-> (2) An employer shall not require a provision made void and unenforceable by subsection (1) of this Section as a condition of employment or continuing employment. This Act shall not preempt existing common law applicable to any shop rights of employers with respect to employees who have not signed an employment agreement.
-> (3) If an employment agreement entered into after January 1, 1984, contains a provision requiring the employee to assign any of the employee's rights in any invention to the employer, the employer must also, at the time the agreement is made, provide a written notification to the employee that the agreement does not apply to an invention for which no equipment, supplies, facility, or trade secret information of the employer was used and which was developed entirely on the employee's own time, unless (a) the invention relates (i) to the business of the employer, or (ii) to the employer's actual or demonstrably anticipated research or development, or (b) the invention results from any work performed by the employee for the employer.
+> (765 ILCS 1060/2) (from Ch. 140, par. 302)  
+> Sec. 2. Employee rights to inventions - conditions). (1) A provision in an employment agreement which provides that an employee shall assign or offer to assign any of the employee's rights in an invention to the employer does not apply to an invention for which no equipment, supplies, facilities, or trade secret information of the employer was used and which was developed entirely on the employee's own time, unless (a) the invention relates (i) to the business of the employer, or (ii) to the employer's actual or demonstrably anticipated research or development, or (b) the invention results from any work performed by the employee for the employer. Any provision which purports to apply to such an invention is to that extent against the public policy of this State and is to that extent void and unenforceable. The employee shall bear the burden of proof in establishing that his invention qualifies under this subsection.  
+> (2) An employer shall not require a provision made void and unenforceable by subsection (1) of this Section as a condition of employment or continuing employment. This Act shall not preempt existing common law applicable to any shop rights of employers with respect to employees who have not signed an employment agreement.  
+> (3) If an employment agreement entered into after January 1, 1984, contains a provision requiring the employee to assign any of the employee's rights in any invention to the employer, the employer must also, at the time the agreement is made, provide a written notification to the employee that the agreement does not apply to an invention for which no equipment, supplies, facility, or trade secret information of the employer was used and which was developed entirely on the employee's own time, unless (a) the invention relates (i) to the business of the employer, or (ii) to the employer's actual or demonstrably anticipated research or development, or (b) the invention results from any work performed by the employee for the employer.  
 > (Source: P.A. 83-493.)
 >
-> (765 ILCS 1060/3) (from Ch. 140, par. 303)
-> Sec. 3. This Act takes effect upon becoming a law.
+> (765 ILCS 1060/3) (from Ch. 140, par. 303)  
+> Sec. 3. This Act takes effect upon becoming a law.  
 > (Source: P.A. 83-493.)
 
 #### Kansas
 
 <http://www.ksrevisor.org/statutes/chapters/ch44/044_001_0030.html>
 
-> 44-130. Employment agreements assigning employee rights in inventions to employer; restrictions; certain provisions void; notice and disclosure. (a) Any provision in an employment agreement which provides that an employee shall assign or offer to assign any of the employee's rights in an invention to the employer shall not apply to an invention for which no equipment, supplies, facilities or trade secret information of the employer was used and which was developed entirely on the employee's own time, unless:
-> (1) The invention relates to the business of the employer or to the employer's actual or demonstrably anticipated research or development; or
-> (2) the invention results from any work performed by the employee for the employer.
-> (b) Any provision in an employment agreement which purports to apply to an invention which it is prohibited from applying to under subsection (a), is to that extent against the public policy of this state and is to that extent void and unenforceable. No employer shall require a provision made void and unenforceable by this section as a condition of employment or continuing employment.
-> (c) If an employment agreement contains a provision requiring the employee to assign any of the employee's rights in any invention to the employer, the employer shall provide, at the time the agreement is made, a written notification to the employee that the agreement does not apply to an invention for which no equipment, supplies, facility or trade secret information of the employer was used and which was developed entirely on the employee's own time, unless:
-> (1) The invention relates directly to the business of the employer or to the employer's actual or demonstrably anticipated research or development; or
-> (2) the invention results from any work performed by the employee for the employer.
-> (d) Even though the employee meets the burden of proving the conditions specified in this section, the employee shall disclose, at the time of employment or thereafter, all inventions being developed by the employee, for the purpose of determining employer and employee rights in an invention.
+> 44-130. Employment agreements assigning employee rights in inventions to employer; restrictions; certain provisions void; notice and disclosure. (a) Any provision in an employment agreement which provides that an employee shall assign or offer to assign any of the employee's rights in an invention to the employer shall not apply to an invention for which no equipment, supplies, facilities or trade secret information of the employer was used and which was developed entirely on the employee's own time, unless:  
+> (1) The invention relates to the business of the employer or to the employer's actual or demonstrably anticipated research or development; or  
+> (2) the invention results from any work performed by the employee for the employer.  
+> (b) Any provision in an employment agreement which purports to apply to an invention which it is prohibited from applying to under subsection (a), is to that extent against the public policy of this state and is to that extent void and unenforceable. No employer shall require a provision made void and unenforceable by this section as a condition of employment or continuing employment.  
+> (c) If an employment agreement contains a provision requiring the employee to assign any of the employee's rights in any invention to the employer, the employer shall provide, at the time the agreement is made, a written notification to the employee that the agreement does not apply to an invention for which no equipment, supplies, facility or trade secret information of the employer was used and which was developed entirely on the employee's own time, unless:  
+> (1) The invention relates directly to the business of the employer or to the employer's actual or demonstrably anticipated research or development; or  
+> (2) the invention results from any work performed by the employee for the employer.  
+> (d) Even though the employee meets the burden of proving the conditions specified in this section, the employee shall disclose, at the time of employment or thereafter, all inventions being developed by the employee, for the purpose of determining employer and employee rights in an invention.  
 > History: L. 1986, ch. 186, § 1; July 1.
 
 #### Minnesota
 
 <https://www.revisor.mn.gov/statutes?id=181.78>
 
-> 181.78 AGREEMENTS; TERMS RELATING TO INVENTIONS.
-> Subdivision 1.Inventions not related to employment. Any provision in an employment agreement which provides that an employee shall assign or offer to assign any of the employee's rights in an invention to the employer shall not apply to an invention for which no equipment, supplies, facility or trade secret information of the employer was used and which was developed entirely on the employee's own time, and (1) which does not relate (a) directly to the business of the employer or (b) to the employer's actual or demonstrably anticipated research or development, or (2) which does not result from any work performed by the employee for the employer. Any provision which purports to apply to such an invention is to that extent against the public policy of this state and is to that extent void and unenforceable.
-> Subd. 2.Effect of subdivision 1. No employer shall require a provision made void and unenforceable by subdivision 1 as a condition of employment or continuing employment.
-> Subd. 3.Notice to employee. If an employment agreement entered into after August 1, 1977 contains a provision requiring the employee to assign or offer to assign any of the employee's rights in any invention to an employer, the employer must also, at the time the agreement is made, provide a written notification to the employee that the agreement does not apply to an invention for which no equipment, supplies, facility or trade secret information of the employer was used and which was developed entirely on the employee's own time, and (1) which does not relate (a) directly to the business of the employer or (b) to the employer's actual or demonstrably anticipated research or development, or (2) which does not result from any work performed by the employee for the employer.
+> 181.78 AGREEMENTS; TERMS RELATING TO INVENTIONS.  
+> Subdivision 1. Inventions not related to employment. Any provision in an employment agreement which provides that an employee shall assign or offer to assign any of the employee's rights in an invention to the employer shall not apply to an invention for which no equipment, supplies, facility or trade secret information of the employer was used and which was developed entirely on the employee's own time, and (1) which does not relate (a) directly to the business of the employer or (b) to the employer's actual or demonstrably anticipated research or development, or (2) which does not result from any work performed by the employee for the employer. Any provision which purports to apply to such an invention is to that extent against the public policy of this state and is to that extent void and unenforceable.  
+> Subd. 2. Effect of subdivision 1. No employer shall require a provision made void and unenforceable by subdivision 1 as a condition of employment or continuing employment.  
+> Subd. 3. Notice to employee. If an employment agreement entered into after August 1, 1977 contains a provision requiring the employee to assign or offer to assign any of the employee's rights in any invention to an employer, the employer must also, at the time the agreement is made, provide a written notification to the employee that the agreement does not apply to an invention for which no equipment, supplies, facility or trade secret information of the employer was used and which was developed entirely on the employee's own time, and (1) which does not relate (a) directly to the business of the employer or (b) to the employer's actual or demonstrably anticipated research or development, or (2) which does not result from any work performed by the employee for the employer.  
 > History: 1977 c 47 s 1; 1986 c 444
 
 #### Nevada
 
 <https://www.leg.state.nv.us/nrs/NRS-600.html#NRS600Sec500>
 
-> NRS 600.500  Employer is sole owner of patentable invention or trade secret developed by employee.  Except as otherwise provided by express written agreement, an employer is the sole owner of any patentable invention or trade secret developed by his or her employee during the course and scope of the employment that relates directly to work performed during the course and scope of the employment.
+> NRS 600.500  Employer is sole owner of patentable invention or trade secret developed by employee.  Except as otherwise provided by express written agreement, an employer is the sole owner of any patentable invention or trade secret developed by his or her employee during the course and scope of the employment that relates directly to work performed during the course and scope of the employment.  
 > (Added to NRS by 2001, 942; A 2003, 2832)
 
 #### North Carolina
@@ -139,53 +138,53 @@ Date: ＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿
 >
 > Inventions Developed by Employee.
 >
-> § 66-57.1.  Employee's right to certain inventions.
+> § 66-57.1.  Employee's right to certain inventions.  
 > Any provision in an employment agreement which provides that the employee shall assign or offer to assign any of his rights in an invention to his employer shall not apply to an invention that the  employee developed entirely on his own time without using the employer's equipment, supplies, facility or trade secret information except for those inventions that (i) relate to the employer's business or actual or demonstrably anticipated research or development, or (ii) result from any work performed by the employee for the employer. To the extent a provision in an employment agreement purports to apply to the type of invention described, it is against the public policy of this State and is unenforceable. The employee shall bear the burden of proof in establishing that his invention qualifies under this section. (1981, c. 488, s. 1.)
 >
-> § 66-57.2.  Employer's rights.
-> (a)        An employer may not require a provision of an employment agreement made unenforceable under G.S. 66-57.1 as a condition of employment or continued employment. An employer, in an employment agreement, may require that the employee report all inventions developed by the employee, solely or jointly, during the term of his employment to the employer, including those asserted by the employee as nonassignable, for the purpose of determining employee or employer rights.
-> (b)        An employer's ownership of an employee's invention, discovery, or development that has or becomes vested in the employer by contract or by operation of law shall not be subject to revocation or rescission in the event of a dispute between the employer and employee concerning payment of compensation or benefits to the employee, subject to any contrary provision in the employee's written employment agreement. The foregoing provision shall not apply where the employee proves that the employer acquired ownership of the employee's invention, discovery, or development fraudulently.
+> § 66-57.2.  Employer's rights.  
+> (a)        An employer may not require a provision of an employment agreement made unenforceable under G.S. 66-57.1 as a condition of employment or continued employment. An employer, in an employment agreement, may require that the employee report all inventions developed by the employee, solely or jointly, during the term of his employment to the employer, including those asserted by the employee as nonassignable, for the purpose of determining employee or employer rights.  
+> (b)        An employer's ownership of an employee's invention, discovery, or development that has or becomes vested in the employer by contract or by operation of law shall not be subject to revocation or rescission in the event of a dispute between the employer and employee concerning payment of compensation or benefits to the employee, subject to any contrary provision in the employee's written employment agreement. The foregoing provision shall not apply where the employee proves that the employer acquired ownership of the employee's invention, discovery, or development fraudulently.  
 > (c)        If required by a contract between the employer and the United States or its agencies, the employer may require that full title to certain patents and inventions be in the United States.  (1981, c. 488, s. 1; 2016-114, s. 4.)
 
 #### Utah
 
 <http://le.utah.gov/xcode/Title34/Chapter39/34-39.html>
 
-> Chapter 39
+> Chapter 39  
 > Employment Inventions Act
 >
-> 34-39-1 Citation of act.
+> 34-39-1 Citation of act.  
 > This act is known as the “Employment Inventions Act.”
 >
 >
 > Enacted by Chapter 217, 1989 General Session
 >
-> 34-39-2 Definitions.
-> As used in this chapter:
-> (1) “Employment invention” means any invention or part thereof conceived, developed, reduced to practice, or created by an employee which is:
-> (a) conceived, developed, reduced to practice, or created by the employee:
-> (i) within the scope of his employment;
-> (ii) on his employer’s time; or
-> (iii) with the aid, assistance, or use of any of his employer’s property, equipment, facilities, supplies, resources, or intellectual property;
-> (b) the result of any work, services, or duties performed by an employee for his employer;
-> (c) related to the industry or trade of the employer; or
-> (d) related to the current or demonstrably anticipated business, research, or development of the employer.
+> 34-39-2 Definitions.  
+> As used in this chapter:  
+> (1) “Employment invention” means any invention or part thereof conceived, developed, reduced to practice, or created by an employee which is:  
+> (a) conceived, developed, reduced to practice, or created by the employee:  
+> (i) within the scope of his employment;  
+> (ii) on his employer’s time; or  
+> (iii) with the aid, assistance, or use of any of his employer’s property, equipment, facilities, supplies, resources, or intellectual property;  
+> (b) the result of any work, services, or duties performed by an employee for his employer;  
+> (c) related to the industry or trade of the employer; or  
+> (d) related to the current or demonstrably anticipated business, research, or development of the employer.  
 > (2) “Intellectual property” means any and all patents, trade secrets, know-how, technology, confidential information, ideas, copyrights, trademarks, and service marks and any and all rights, applications, and registrations relating to them.
 >
 > Enacted by Chapter 217, 1989 General Session
 >
-> 34-39-3 Scope of act -- When agreements between an employee and employer are enforceable or unenforceable with respect to employment inventions -- Exceptions.
-> (1) An employment agreement between an employee and his employer is not enforceable against the employee to the extent that the agreement requires the employee to assign or license, or to offer to assign or license, to the employer any right or intellectual property in or to an invention that is:
-> (a) created by the employee entirely on his own time; and
-> (b) not an employment invention.
-> (2) An agreement between an employee and his employer may require the employee to assign or license, or to offer to assign or license, to his employer any or all of his rights and intellectual property in or to an employment invention.
-> (3) Subsection (1) does not apply to:
-> (a) any right, intellectual property or invention that is required by law or by contract between the employer and the United States government or a state or local government to be assigned or licensed to the United States; or
-> (b) an agreement between an employee and his employer which is not an employment agreement.
-> (4) Notwithstanding Subsection (1), an agreement is enforceable under Subsection (1) if the employee’s employment or continuation of employment is not conditioned on the employee’s acceptance of such agreement and the employee receives a consideration under such agreement which is not compensation for employment.
-> (5) Employment of the employee or the continuation of his employment is sufficient consideration to support the enforceability of an agreement under Subsection (2) whether or not the agreement recites such consideration.
-> (6) An employer may require his employees to agree to an agreement within the scope of Subsection (2) as a condition of employment or the continuation of employment.
-> (7) An employer may not require his employees to agree to anything unenforceable under Subsection (1) as a condition of employment or the continuation of employment.
+> 34-39-3 Scope of act -- When agreements between an employee and employer are enforceable or unenforceable with respect to employment inventions -- Exceptions.  
+> (1) An employment agreement between an employee and his employer is not enforceable against the employee to the extent that the agreement requires the employee to assign or license, or to offer to assign or license, to the employer any right or intellectual property in or to an invention that is:  
+> (a) created by the employee entirely on his own time; and  
+> (b) not an employment invention.  
+> (2) An agreement between an employee and his employer may require the employee to assign or license, or to offer to assign or license, to his employer any or all of his rights and intellectual property in or to an employment invention.  
+> (3) Subsection (1) does not apply to:  
+> (a) any right, intellectual property or invention that is required by law or by contract between the employer and the United States government or a state or local government to be assigned or licensed to the United States; or  
+> (b) an agreement between an employee and his employer which is not an employment agreement.  
+> (4) Notwithstanding Subsection (1), an agreement is enforceable under Subsection (1) if the employee’s employment or continuation of employment is not conditioned on the employee’s acceptance of such agreement and the employee receives a consideration under such agreement which is not compensation for employment.  
+> (5) Employment of the employee or the continuation of his employment is sufficient consideration to support the enforceability of an agreement under Subsection (2) whether or not the agreement recites such consideration.  
+> (6) An employer may require his employees to agree to an agreement within the scope of Subsection (2) as a condition of employment or the continuation of employment.  
+> (7) An employer may not require his employees to agree to anything unenforceable under Subsection (1) as a condition of employment or the continuation of employment.  
 > (8) Nothing in this chapter invalidates or renders unenforceable any employment agreement or provisions of an employment agreement unrelated to employment inventions.
 >
 > Enacted by Chapter 217, 1989 General Session
@@ -195,8 +194,10 @@ Date: ＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿＿
 <http://app.leg.wa.gov/RCW/default.aspx?cite=49.44.140>
 
 > RCW 49.44.140
-> Requiring assignment of employee's rights to inventions—Conditions.
-> (1) A provision in an employment agreement which provides that an employee shall assign or offer to assign any of the employee's rights in an invention to the employer does not apply to an invention for which no equipment, supplies, facilities, or trade secret information of the employer was used and which was developed entirely on the employee's own time, unless (a) the invention relates (i) directly to the business of the employer, or (ii) to the employer's actual or demonstrably anticipated research or development, or (b) the invention results from any work performed by the employee for the employer. Any provision which purports to apply to such an invention is to that extent against the public policy of this state and is to that extent void and unenforceable.
-> (2) An employer shall not require a provision made void and unenforceable by subsection (1) of this section as a condition of employment or continuing employment.
+>
+> Requiring assignment of employee's rights to inventions—Conditions.  
+> (1) A provision in an employment agreement which provides that an employee shall assign or offer to assign any of the employee's rights in an invention to the employer does not apply to an invention for which no equipment, supplies, facilities, or trade secret information of the employer was used and which was developed entirely on the employee's own time, unless (a) the invention relates (i) directly to the business of the employer, or (ii) to the employer's actual or demonstrably anticipated research or development, or (b) the invention results from any work performed by the employee for the employer. Any provision which purports to apply to such an invention is to that extent against the public policy of this state and is to that extent void and unenforceable.  
+> (2) An employer shall not require a provision made void and unenforceable by subsection (1) of this section as a condition of employment or continuing employment.  
 > (3) If an employment agreement entered into after September 1, 1979, contains a provision requiring the employee to assign any of the employee's rights in any invention to the employer, the employer must also, at the time the agreement is made, provide a written notification to the employee that the agreement does not apply to an invention for which no equipment, supplies, facility, or trade secret information of the employer was used and which was developed entirely on the employee's own time, unless (a) the invention relates (i) directly to the business of the employer, or (ii) to the employer's actual or demonstrably anticipated research or development, or (b) the invention results from any work preformed [performed] by the employee for the employer.
+> 
 > [ 1979 ex.s. c 177 § 2.]


### PR DESCRIPTION
Toward fixing #28

However, there are problems:

- The California lines starting with 2870. etc are taken as a numbered list -- starting from 1.
- Line breaks aren't rendered without a blank line between them.

I suspect to make this work have to do further for-markdown formatting (introducing blank lines, which doesn't look great in some cases) and for California, additionally either slightly changing the text so that leading numbers aren't taken to denote an numbered list..perhaps `2870.` -> `2870)`.

If my suspicion is correct (hopefully I'm missing some tricks), I don't think this is a great solution.