### PR TITLE
Clarify pronunciation guide.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ From an IP (copyright) perspective, the agreement is dedicated to the public dom
 
 ### How is BEIPA pronounced?
 
-Think Beijing. Say Bay-pa.
+In English, think Beijing. Say Bay-pa.
+
+In other languages, use the natural pronunciation based in the spelling.
 
 ### What are some other relatively balanced approaches?
 


### PR DESCRIPTION
This clarifies that the pronunciation guide "Bay-pa" applies to English only, and that other languages (with more sensible spelling systems) should use their natural pronunciation of the spelling.